### PR TITLE
fix: Add check for empty delta in OpenAI legacy chat

### DIFF
--- a/src/kosong/chat_provider/openai_legacy.py
+++ b/src/kosong/chat_provider/openai_legacy.py
@@ -164,6 +164,9 @@ class OpenAILegacyStreamedMessage:
 
                 delta = chunk.choices[0].delta
 
+                if not delta:
+                    continue
+
                 # convert text content
                 if delta.content:
                     yield TextPart(text=delta.content)


### PR DESCRIPTION
Kimi-cli raises an error when using Minimax: 
```
kimi-cli/lib/python3.13/site-packages/kosong/chat_provider/openai_legacy.py", line 168, in _convert_stream_response
    if delta.content:
       ^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'content'
```

Because MiniMax-M2 returns `Choice(delta=None, finish_reason='stop', index=0, logprobs=None, message={'content': '', 'role': 'assistant', 'name': 'MiniMax AI',
'audio_content': '', 'reasoning_content': ''})` in the end. 
