### PR TITLE
fix(anthropic): handle None case for `input_other` in `TokenUsage`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+- Fix token usage for Anthropic chat provider
+
 ## [0.27.2] - 2025-11-25
 
 - Support non-OpenAI models which do not accept `developer` role in system prompt in `OpenAIResponses` chat provider


### PR DESCRIPTION
This is causing the Kimi CLI to break when using the Anthropic API as when the input is calculated the following error occurs

self = TokenUsage(input_other=None, output=0, input_cache_read=0, input_cache_creation=0)  TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'


https://github.com/MoonshotAI/kosong/blob/4c25822441fda91bea52dbd10f16365883996ea8/src/kosong/chat_provider/__init__.py#L93C17-L93C18

Related to issue https://github.com/MoonshotAI/kimi-cli/issues/264 