### PR TITLE
feat: Add thinking signature to Anthropic provider non-stream mode

### DIFF
--- a/src/kosong/contrib/chat_provider/anthropic.py
+++ b/src/kosong/contrib/chat_provider/anthropic.py
@@ -279,7 +279,7 @@ class AnthropicStreamedMessage:
                 case "text":
                     yield TextPart(text=block.text)
                 case "thinking":
-                    yield ThinkPart(think=block.thinking)
+                    yield ThinkPart(think=block.thinking, encrypted=block.signature)
                 case "redacted_thinking":
                     yield ThinkPart(think="", encrypted=block.data)
                 case "tool_use":


### PR DESCRIPTION
 Add thinking signature to Anthropic provider non-stream mode
<img width="2066" height="461" alt="image" src="https://github.com/user-attachments/assets/2e61cc73-0313-43a1-b873-2c498f3eaebc" />
