### PR TITLE
Make DeepSeek R1 tool function call work by convert Array to string to avoid 400 error.

### DIFF
--- a/tests/test_openai_legacy.py
+++ b/tests/test_openai_legacy.py
@@ -1,4 +1,4 @@
-from kosong.contrib.chat_provider.openai_legacy import message_to_openai
+from kosong.contrib.chat_provider.openai_legacy import OpenAILegacy, message_to_openai
 from kosong.message import (
     AudioURLPart,
     ContentPart,
@@ -51,3 +51,23 @@ def test_message_to_openai_skips_unsupported_tool_content_parts():
     content = converted["content"]
 
     assert content == "{'type': 'text', 'text': 'kept text'}"
+
+
+def test_message_to_openai_includes_empty_reasoning_for_assistant_when_requested():
+    message = Message(role="assistant", content=[])
+
+    converted = message_to_openai(message, reasoning_key="reasoning_content")
+
+    assert converted["reasoning_content"] == ""
+    assert converted["role"] == "assistant"
+
+
+def test_openai_legacy_defaults_reasoning_key_for_deepseek():
+    provider = OpenAILegacy(
+        model="deepseek-chat",
+        api_key="sk-test",
+        base_url="https://api.deepseek.com",
+        stream=False,
+    )
+
+    assert provider.reasoning_key == "reasoning_content"


### PR DESCRIPTION
DeepSeek R1 [document site](https://api-docs.deepseek.com/api/create-chat-completion/)

<img width="738" height="834" alt="image" src="https://github.com/user-attachments/assets/e5307ca2-12e8-4e3c-a1ca-4c01ffe7caac" />

But [OpenAI document site say](https://platform.openai.com/docs/api-reference/chat/create?utm_source=chatgpt.com)

<img width="719" height="486" alt="image" src="https://github.com/user-attachments/assets/592b8845-2542-45ee-bb22-f221574e268b" />

So here is difference.

It analyzed by below log with prompt "Please analyze why the function call id call_00_RxSgccSLgJCh0ZuG54yXGH5W is cause the 400 error and propose a fix in kimi-cli or kosong." to codex-max-vhigh.

```log
2025-11-24 19:40:55.241 | DEBUG    | kimi_cli.soul.context:append_message:135 - Appending message(s) to context: role='user' name=None content=[TextPart(type='text', text='howto configure kimi cli with ANTHROPIC style key?')] tool_calls=None tool_call_id=None partial=None
2025-11-24 19:40:55.241 | DEBUG    | kimi_cli.soul.kimisoul:run:173 - Appended user message to context
2025-11-24 19:40:55.241 | DEBUG    | kimi_cli.wire:send:51 - Sending wire message: n=1
2025-11-24 19:40:55.241 | DEBUG    | kimi_cli.soul.kimisoul:_agent_loop:223 - Beginning step 1
2025-11-24 19:40:55.241 | DEBUG    | kimi_cli.soul.context:checkpoint:71 - Checkpointing, ID: 1
2025-11-24 19:40:55.241 | DEBUG    | kimi_cli.wire:receive:69 - Receiving wire message: n=1
2025-11-24 19:40:55.242 | TRACE    | kosong._generate:generate:52 - Generating with history: [Message(role='assistant', name=None, content=[TextPart(type='text', text='<system>kimi-cli::agents-md:ab602e64b1c2d4cf82b9e2ce00b96f4c808158ae6bc306c58ad9fae151cbf5b9\nMarkdown files named `AGENTS.md` usually contain the background, structure, coding styles, user preferences, and other relevant information about the project. Use this information to understand the project context. The following content is the current `/Users/guochunzhong/git/oss/kimi-cli/AGENTS.md`:\n\n---\n# Repository Guidelines\n\n## Project Structure & Module Organization\n- Core Python sources live under `src/kimi_cli` (CLI entrypoint, UI, tools, agents, prompts, utils, wire-up). Shared bits for packaging live in `src/kaos`.\n- Tests: unit/integration specs in `tests/`; AI scenarios and scripts in `tests_ai/` (heavier, may hit live services). Docs and images live in `docs/`. Build outputs go to `build/` and `dist/` (keep clean in commits).\n\n## Build, Test, and Development Commands\n- `make prepare` — sync dependencies via `uv` using the locked versions in `uv.lock`.\n- `uv run kimi` — launch the CLI locally from the source tree.\n- `make format` — auto-fix style with Ruff, then format.\n- `make check` — Ruff lint (no fixes), format check, and Pyright type check.\n- `make test` — run the pytest suite in `tests/`.\n- `make ai-test` — run `tests_ai` flows; expect longer runtimes and possible external calls.\n- `make build` — package the standalone binary with PyInstaller.\n\n## Coding Style & Naming Conventions\n- Python 3.13; default line length 100. Prefer typed functions and early returns.\n- Use Ruff format and lint rules (`ruff check`; keep imports ordered). Run `make format` before sending PRs.\n- Naming: modules and functions `snake_case`, classes `PascalCase`, constants `UPPER_SNAKE`. Keep prompt/config files under `src/kimi_cli/prompts` and tooling under `src/kimi_cli/tools`.\n\n## Testing Guidelines\n- Framework: pytest (+pytest-asyncio). Place new specs alongside the feature in `tests/` with descriptive names like `test_cli_shell_mode.py`.\n- Keep tests deterministic; avoid network calls unless in `tests_ai` and guard them with markers or fixtures.\n- When changing prompts or agent wiring, add scenario coverage or update snapshots where applicable.\n\n## Commit & Pull Request Guidelines\n- Commit messages: short, present-tense summaries similar to existing history.\n- Pull requests: include a concise description of behavior changes, test evidence (`make test` / `make ai-test` notes), and any docs updates. Link related issues. For user-facing output changes, add before/after screenshots or terminal transcripts when feasible.\n---</system>')], tool_calls=None, tool_call_id=None, partial=None), Message(role='user', name=None, content=[TextPart(type='text', text='howto configure kimi cli with ANTHROPIC style key?')], tool_calls=None, tool_call_id=None, partial=None)]
2025-11-24 19:40:56.651 | TRACE    | kosong._generate:generate:55 - Received part: type='text' text='I'
2025-11-24 19:40:56.974 | TRACE    | kosong._generate:generate:55 - Received part: type='text' text="'ll"
2025-11-24 19:40:56.996 | TRACE    | kosong._generate:generate:55 - Received part: type='text' text=' help'
2025-11-24 19:40:56.997 | TRACE    | kosong._generate:generate:55 - Received part: type='text' text=' you'
2025-11-24 19:40:57.059 | TRACE    | kosong._generate:generate:55 - Received part: type='text' text=' configure'
2025-11-24 19:40:57.060 | TRACE    | kosong._generate:generate:55 - Received part: type='text' text=' Kim'
2025-11-24 19:40:57.124 | TRACE    | kosong._generate:generate:55 - Received part: type='text' text='i'
2025-11-24 19:40:57.125 | TRACE    | kosong._generate:generate:55 - Received part: type='text' text=' CLI'
2025-11-24 19:40:57.196 | TRACE    | kosong._generate:generate:55 - Received part: type='text' text=' with'
2025-11-24 19:40:57.197 | TRACE    | kosong._generate:generate:55 - Received part: type='text' text=' Anthrop'
2025-11-24 19:40:57.259 | TRACE    | kosong._generate:generate:55 - Received part: type='text' text='ic'
2025-11-24 19:40:57.260 | TRACE    | kosong._generate:generate:55 - Received part: type='text' text='-style'
2025-11-24 19:40:57.325 | TRACE    | kosong._generate:generate:55 - Received part: type='text' text=' API'
2025-11-24 19:40:57.326 | TRACE    | kosong._generate:generate:55 - Received part: type='text' text=' key'
2025-11-24 19:40:57.391 | TRACE    | kosong._generate:generate:55 - Received part: type='text' text='.'
2025-11-24 19:40:57.392 | TRACE    | kosong._generate:generate:55 - Received part: type='text' text=' Let'
2025-11-24 19:40:57.458 | TRACE    | kosong._generate:generate:55 - Received part: type='text' text=' me'
2025-11-24 19:40:57.459 | TRACE    | kosong._generate:generate:55 - Received part: type='text' text=' first'
2025-11-24 19:40:57.526 | TRACE    | kosong._generate:generate:55 - Received part: type='text' text=' explore'
2025-11-24 19:40:57.593 | TRACE    | kosong._generate:generate:55 - Received part: type='text' text=' the'
2025-11-24 19:40:57.594 | TRACE    | kosong._generate:generate:55 - Received part: type='text' text=' project'
2025-11-24 19:40:57.679 | TRACE    | kosong._generate:generate:55 - Received part: type='text' text=' structure'
2025-11-24 19:40:57.680 | TRACE    | kosong._generate:generate:55 - Received part: type='text' text=' to'
2025-11-24 19:40:57.733 | TRACE    | kosong._generate:generate:55 - Received part: type='text' text=' understand'
2025-11-24 19:40:57.734 | TRACE    | kosong._generate:generate:55 - Received part: type='text' text=' how'
2025-11-24 19:40:57.796 | TRACE    | kosong._generate:generate:55 - Received part: type='text' text=' configuration'
2025-11-24 19:40:57.797 | TRACE    | kosong._generate:generate:55 - Received part: type='text' text=' works'
2025-11-24 19:40:57.858 | TRACE    | kosong._generate:generate:55 - Received part: type='text' text='.'
2025-11-24 19:40:57.994 | TRACE    | kosong._generate:generate:55 - Received part: type='function' id='call_00_RxSgccSLgJCh0ZuG54yXGH5W' function=FunctionBody(name='Grep', arguments='') extras=None
2025-11-24 19:40:57.994 | DEBUG    | kimi_cli.wire:send:51 - Sending wire message: type='function' id='call_00_RxSgccSLgJCh0ZuG54yXGH5W' function=FunctionBody(name='Grep', arguments='') extras=None
2025-11-24 19:40:57.995 | DEBUG    | kimi_cli.wire:receive:69 - Receiving wire message: type='function' id='call_00_RxSgccSLgJCh0ZuG54yXGH5W' function=FunctionBody(name='Grep', arguments='') extras=None
2025-11-24 19:40:58.065 | TRACE    | kosong._generate:generate:55 - Received part: arguments_part='{"'
2025-11-24 19:40:58.067 | TRACE    | kosong._generate:generate:55 - Received part: arguments_part='pattern'
2025-11-24 19:40:58.219 | TRACE    | kosong._generate:generate:55 - Received part: arguments_part='":'
2025-11-24 19:40:58.220 | TRACE    | kosong._generate:generate:55 - Received part: arguments_part=' "'
2025-11-24 19:40:58.222 | TRACE    | kosong._generate:generate:55 - Received part: arguments_part='anthrop'
2025-11-24 19:40:58.222 | TRACE    | kosong._generate:generate:55 - Received part: arguments_part='ic'
2025-11-24 19:40:58.266 | TRACE    | kosong._generate:generate:55 - Received part: arguments_part='|'
2025-11-24 19:40:58.266 | TRACE    | kosong._generate:generate:55 - Received part: arguments_part='AN'
2025-11-24 19:40:58.327 | TRACE    | kosong._generate:generate:55 - Received part: arguments_part='TH'
2025-11-24 19:40:58.328 | TRACE    | kosong._generate:generate:55 - Received part: arguments_part='ROP'
2025-11-24 19:40:58.390 | TRACE    | kosong._generate:generate:55 - Received part: arguments_part='IC'
2025-11-24 19:40:58.391 | TRACE    | kosong._generate:generate:55 - Received part: arguments_part='",'
2025-11-24 19:40:58.464 | TRACE    | kosong._generate:generate:55 - Received part: arguments_part=' "'
2025-11-24 19:40:58.465 | TRACE    | kosong._generate:generate:55 - Received part: arguments_part='output'
2025-11-24 19:40:58.524 | TRACE    | kosong._generate:generate:55 - Received part: arguments_part='_mode'
2025-11-24 19:40:58.525 | TRACE    | kosong._generate:generate:55 - Received part: arguments_part='":'
2025-11-24 19:40:58.591 | TRACE    | kosong._generate:generate:55 - Received part: arguments_part=' "'
2025-11-24 19:40:58.593 | TRACE    | kosong._generate:generate:55 - Received part: arguments_part='files'
2025-11-24 19:40:58.678 | TRACE    | kosong._generate:generate:55 - Received part: arguments_part='_with'
2025-11-24 19:40:58.679 | TRACE    | kosong._generate:generate:55 - Received part: arguments_part='_m'
2025-11-24 19:40:58.723 | TRACE    | kosong._generate:generate:55 - Received part: arguments_part='atches'
2025-11-24 19:40:58.724 | TRACE    | kosong._generate:generate:55 - Received part: arguments_part='",'
2025-11-24 19:40:58.795 | TRACE    | kosong._generate:generate:55 - Received part: arguments_part=' "-'
2025-11-24 19:40:58.795 | TRACE    | kosong._generate:generate:55 - Received part: arguments_part='i'
2025-11-24 19:40:58.859 | TRACE    | kosong._generate:generate:55 - Received part: arguments_part='":'
2025-11-24 19:40:58.860 | TRACE    | kosong._generate:generate:55 - Received part: arguments_part=' true'
2025-11-24 19:40:58.923 | TRACE    | kosong._generate:generate:55 - Received part: arguments_part='}'
2025-11-24 19:40:58.997 | DEBUG    | kimi_cli.soul.kimisoul:_step:271 - Got step result: StepResult(id='b8b29637-959a-4e6e-b3d4-8d7f680994ff', message=Message(role='assistant', name=None, content=[TextPart(type='text', text="I'll help you configure Kimi CLI with Anthropic-style API key. Let me first explore the project structure to understand how configuration works.")], tool_calls=[ToolCall(type='function', id='call_00_RxSgccSLgJCh0ZuG54yXGH5W', function=FunctionBody(name='Grep', arguments='{"pattern": "anthropic|ANTHROPIC", "output_mode": "files_with_matches", "-i": true}'), extras=None)], tool_call_id=None, partial=None), usage=TokenUsage(input_other=5040, output=62, input_cache_read=1216, input_cache_creation=0), tool_calls=[ToolCall(type='function', id='call_00_RxSgccSLgJCh0ZuG54yXGH5W', function=FunctionBody(name='Grep', arguments='{"pattern": "anthropic|ANTHROPIC", "output_mode": "files_with_matches", "-i": true}'), extras=None)], _tool_result_futures={'call_00_RxSgccSLgJCh0ZuG54yXGH5W': <Task pending name='Task-35' coro=<SimpleToolset.handle.<locals>._call() running at /Users/guochunzhong/git/oss/kimi-cli/.venv/lib/python3.13/site-packages/kosong/tooling/simple.py:90> cb=[step.<locals>.future_done_callback() at /Users/guochunzhong/git/oss/kimi-cli/.venv/lib/python3.13/site-packages/kosong/__init__.py:136]>})
2025-11-24 19:40:58.997 | DEBUG    | kimi_cli.soul.context:update_token_count:157 - Updating token count in context: 6256
2025-11-24 19:40:58.999 | DEBUG    | kimi_cli.tools.file.grep_local:__call__:255 - Using ripgrep binary: /Users/guochunzhong/git/oss/kimi-cli/src/kimi_cli/deps/bin/rg
2025-11-24 19:40:59.033 | DEBUG    | kimi_cli.wire:send:51 - Sending wire message: ToolResult(tool_call_id='call_00_RxSgccSLgJCh0ZuG54yXGH5W', result=ToolOk(output='./CHANGELOG.md\n./uv.lock\n./src/kimi_cli/llm.py\n', message='', brief=''))
2025-11-24 19:40:59.034 | DEBUG    | kimi_cli.wire:receive:69 - Receiving wire message: ToolResult(tool_call_id='call_00_RxSgccSLgJCh0ZuG54yXGH5W', result=ToolOk(output='./CHANGELOG.md\n./uv.lock\n./src/kimi_cli/llm.py\n', message='', brief=''))
2025-11-24 19:40:59.035 | DEBUG    | kimi_cli.wire:send:51 - Sending wire message: status=StatusSnapshot(context_usage=0.095458984375)
2025-11-24 19:40:59.035 | DEBUG    | kimi_cli.soul.kimisoul:_step:279 - Got tool results: [ToolResult(tool_call_id='call_00_RxSgccSLgJCh0ZuG54yXGH5W', result=ToolOk(output='./CHANGELOG.md\n./uv.lock\n./src/kimi_cli/llm.py\n', message='', brief=''))]
2025-11-24 19:40:59.035 | DEBUG    | kimi_cli.wire:receive:69 - Receiving wire message: status=StatusSnapshot(context_usage=0.095458984375)
2025-11-24 19:40:59.035 | DEBUG    | kimi_cli.soul.kimisoul:_grow_context:318 - Growing context with result: StepResult(id='b8b29637-959a-4e6e-b3d4-8d7f680994ff', message=Message(role='assistant', name=None, content=[TextPart(type='text', text="I'll help you configure Kimi CLI with Anthropic-style API key. Let me first explore the project structure to understand how configuration works.")], tool_calls=[ToolCall(type='function', id='call_00_RxSgccSLgJCh0ZuG54yXGH5W', function=FunctionBody(name='Grep', arguments='{"pattern": "anthropic|ANTHROPIC", "output_mode": "files_with_matches", "-i": true}'), extras=None)], tool_call_id=None, partial=None), usage=TokenUsage(input_other=5040, output=62, input_cache_read=1216, input_cache_creation=0), tool_calls=[ToolCall(type='function', id='call_00_RxSgccSLgJCh0ZuG54yXGH5W', function=FunctionBody(name='Grep', arguments='{"pattern": "anthropic|ANTHROPIC", "output_mode": "files_with_matches", "-i": true}'), extras=None)], _tool_result_futures={})
2025-11-24 19:40:59.035 | DEBUG    | kimi_cli.soul.context:append_message:135 - Appending message(s) to context: role='assistant' name=None content=[TextPart(type='text', text="I'll help you configure Kimi CLI with Anthropic-style API key. Let me first explore the project structure to understand how configuration works.")] tool_calls=[ToolCall(type='function', id='call_00_RxSgccSLgJCh0ZuG54yXGH5W', function=FunctionBody(name='Grep', arguments='{"pattern": "anthropic|ANTHROPIC", "output_mode": "files_with_matches", "-i": true}'), extras=None)] tool_call_id=None partial=None
2025-11-24 19:40:59.036 | DEBUG    | kimi_cli.soul.context:update_token_count:157 - Updating token count in context: 6318
2025-11-24 19:40:59.036 | DEBUG    | kimi_cli.soul.kimisoul:_grow_context:334 - Appending tool messages to context: [Message(role='tool', name=None, content=[TextPart(type='text', text='./CHANGELOG.md\n./uv.lock\n./src/kimi_cli/llm.py\n')], tool_calls=None, tool_call_id='call_00_RxSgccSLgJCh0ZuG54yXGH5W', partial=None)]
2025-11-24 19:40:59.036 | DEBUG    | kimi_cli.soul.context:append_message:135 - Appending message(s) to context: [Message(role='tool', name=None, content=[TextPart(type='text', text='./CHANGELOG.md\n./uv.lock\n./src/kimi_cli/llm.py\n')], tool_calls=None, tool_call_id='call_00_RxSgccSLgJCh0ZuG54yXGH5W', partial=None)]
2025-11-24 19:40:59.036 | DEBUG    | kimi_cli.wire:send:51 - Sending wire message: n=2
2025-11-24 19:40:59.036 | DEBUG    | kimi_cli.soul.kimisoul:_agent_loop:223 - Beginning step 2
2025-11-24 19:40:59.036 | DEBUG    | kimi_cli.soul.context:checkpoint:71 - Checkpointing, ID: 2
2025-11-24 19:40:59.036 | DEBUG    | kimi_cli.wire:receive:69 - Receiving wire message: n=2
2025-11-24 19:40:59.037 | TRACE    | kosong._generate:generate:52 - Generating with history: [Message(role='assistant', name=None, content=[TextPart(type='text', text='<system>kimi-cli::agents-md:ab602e64b1c2d4cf82b9e2ce00b96f4c808158ae6bc306c58ad9fae151cbf5b9\nMarkdown files named `AGENTS.md` usually contain the background, structure, coding styles, user preferences, and other relevant information about the project. Use this information to understand the project context. The following content is the current `/Users/guochunzhong/git/oss/kimi-cli/AGENTS.md`:\n\n---\n# Repository Guidelines\n\n## Project Structure & Module Organization\n- Core Python sources live under `src/kimi_cli` (CLI entrypoint, UI, tools, agents, prompts, utils, wire-up). Shared bits for packaging live in `src/kaos`.\n- Tests: unit/integration specs in `tests/`; AI scenarios and scripts in `tests_ai/` (heavier, may hit live services). Docs and images live in `docs/`. Build outputs go to `build/` and `dist/` (keep clean in commits).\n\n## Build, Test, and Development Commands\n- `make prepare` — sync dependencies via `uv` using the locked versions in `uv.lock`.\n- `uv run kimi` — launch the CLI locally from the source tree.\n- `make format` — auto-fix style with Ruff, then format.\n- `make check` — Ruff lint (no fixes), format check, and Pyright type check.\n- `make test` — run the pytest suite in `tests/`.\n- `make ai-test` — run `tests_ai` flows; expect longer runtimes and possible external calls.\n- `make build` — package the standalone binary with PyInstaller.\n\n## Coding Style & Naming Conventions\n- Python 3.13; default line length 100. Prefer typed functions and early returns.\n- Use Ruff format and lint rules (`ruff check`; keep imports ordered). Run `make format` before sending PRs.\n- Naming: modules and functions `snake_case`, classes `PascalCase`, constants `UPPER_SNAKE`. Keep prompt/config files under `src/kimi_cli/prompts` and tooling under `src/kimi_cli/tools`.\n\n## Testing Guidelines\n- Framework: pytest (+pytest-asyncio). Place new specs alongside the feature in `tests/` with descriptive names like `test_cli_shell_mode.py`.\n- Keep tests deterministic; avoid network calls unless in `tests_ai` and guard them with markers or fixtures.\n- When changing prompts or agent wiring, add scenario coverage or update snapshots where applicable.\n\n## Commit & Pull Request Guidelines\n- Commit messages: short, present-tense summaries similar to existing history.\n- Pull requests: include a concise description of behavior changes, test evidence (`make test` / `make ai-test` notes), and any docs updates. Link related issues. For user-facing output changes, add before/after screenshots or terminal transcripts when feasible.\n---</system>')], tool_calls=None, tool_call_id=None, partial=None), Message(role='user', name=None, content=[TextPart(type='text', text='howto configure kimi cli with ANTHROPIC style key?')], tool_calls=None, tool_call_id=None, partial=None), Message(role='assistant', name=None, content=[TextPart(type='text', text="I'll help you configure Kimi CLI with Anthropic-style API key. Let me first explore the project structure to understand how configuration works.")], tool_calls=[ToolCall(type='function', id='call_00_RxSgccSLgJCh0ZuG54yXGH5W', function=FunctionBody(name='Grep', arguments='{"pattern": "anthropic|ANTHROPIC", "output_mode": "files_with_matches", "-i": true}'), extras=None)], tool_call_id=None, partial=None), Message(role='tool', name=None, content=[TextPart(type='text', text='./CHANGELOG.md\n./uv.lock\n./src/kimi_cli/llm.py\n')], tool_calls=None, tool_call_id='call_00_RxSgccSLgJCh0ZuG54yXGH5W', partial=None)]
2025-11-24 19:40:59.262 | DEBUG    | kimi_cli.wire:send:51 - Sending wire message: 
2025-11-24 19:40:59.263 | DEBUG    | kimi_cli.wire:receive:69 - Receiving wire message: 
2025-11-24 19:40:59.263 | DEBUG    | kimi_cli.soul:run_soul:150 - Shutting down the UI loop
2025-11-24 19:40:59.263 | DEBUG    | kimi_cli.wire:shutdown:37 - Shutting down wire
2025-11-24 19:40:59.275 | ERROR    | kimi_cli.ui.shell:_run_soul_command:219 - LLM provider error:
Traceback (most recent call last):

  File "/Users/guochunzhong/git/oss/kimi-cli/.venv/lib/python3.13/site-packages/kosong/contrib/chat_provider/openai_legacy.py", line 114, in generate
    response = await self.client.chat.completions.create(
                     │    │      │    │           └ <function AsyncCompletions.create at 0x109b205e0>
                     │    │      │    └ <openai.resources.chat.completions.completions.AsyncCompletions object at 0x10a0181a0>
                     │    │      └ <openai.resources.chat.chat.AsyncChat object at 0x10a018050>
                     │    └ <openai.AsyncOpenAI object at 0x107a32f90>
                     └ <kosong.contrib.chat_provider.openai_legacy.OpenAILegacy object at 0x10a051590>
  File "/Users/guochunzhong/git/oss/kimi-cli/.venv/lib/python3.13/site-packages/openai/resources/chat/completions/completions.py", line 2672, in create
    return await self._post(
                 │    └ <bound method AsyncAPIClient.post of <openai.AsyncOpenAI object at 0x107a32f90>>
                 └ <openai.resources.chat.completions.completions.AsyncCompletions object at 0x10a0181a0>
  File "/Users/guochunzhong/git/oss/kimi-cli/.venv/lib/python3.13/site-packages/openai/_base_client.py", line 1794, in post
    return await self.request(cast_to, opts, stream=stream, stream_cls=stream_cls)
                 │    │       │        │            │                  └ openai.AsyncStream[openai.types.chat.chat_completion_chunk.ChatCompletionChunk]
                 │    │       │        │            └ True
                 │    │       │        └ FinalRequestOptions(method='post', url='/chat/completions', params={}, headers=NOT_GIVEN, max_retries=NOT_GIVEN, timeout=NOT_...
                 │    │       └ <class 'openai.types.chat.chat_completion.ChatCompletion'>
                 │    └ <function AsyncAPIClient.request at 0x107a85120>
                 └ <openai.AsyncOpenAI object at 0x107a32f90>
  File "/Users/guochunzhong/git/oss/kimi-cli/.venv/lib/python3.13/site-packages/openai/_base_client.py", line 1594, in request
    raise self._make_status_error_from_response(err.response) from None
          │    └ <function BaseClient._make_status_error_from_response at 0x107a7e2a0>
          └ <openai.AsyncOpenAI object at 0x107a32f90>

openai.BadRequestError: Error code: 400 - {'error': {'message': 'Failed to deserialize the JSON body into the target type: messages[4]: invalid type: sequence, expected a string at line 1 column 8822', 'type': 'invalid_request_error', 'param': None, 'code': 'invalid_request_error'}}


The above exception was the direct cause of the following exception:


Traceback (most recent call last):

  File "/Users/guochunzhong/git/oss/kimi-cli/.venv/bin/kimi", line 10, in <module>
    sys.exit(cli())
    │   │    └ <typer.main.Typer object at 0x105888440>
    │   └ <built-in function exit>
    └ <module 'sys' (built-in)>
  File "/Users/guochunzhong/git/oss/kimi-cli/.venv/lib/python3.13/site-packages/typer/main.py", line 310, in __call__
    return get_command(self)(*args, **kwargs)
           │           │      │       └ {}
           │           │      └ ()
           │           └ <typer.main.Typer object at 0x105888440>
           └ <function get_command at 0x105808360>
  File "/Users/guochunzhong/git/oss/kimi-cli/.venv/lib/python3.13/site-packages/click/core.py", line 1485, in __call__
    return self.main(*args, **kwargs)
           │    │     │       └ {}
           │    │     └ ()
           │    └ <function TyperCommand.main at 0x1057e7880>
           └ <TyperCommand kimi>
  File "/Users/guochunzhong/git/oss/kimi-cli/.venv/lib/python3.13/site-packages/typer/core.py", line 719, in main
    return _main(
           └ <function _main at 0x1057e6a20>
  File "/Users/guochunzhong/git/oss/kimi-cli/.venv/lib/python3.13/site-packages/typer/core.py", line 192, in _main
    rv = self.invoke(ctx)
         │    │      └ <click.core.Context object at 0x10588ba10>
         │    └ <function Command.invoke at 0x105773060>
         └ <TyperCommand kimi>
  File "/Users/guochunzhong/git/oss/kimi-cli/.venv/lib/python3.13/site-packages/click/core.py", line 1269, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           │   │      │    │           │   └ {'version': None, 'model_name': 'deepseek-r1', 'debug': True, 'verbose': False, 'agent_file': None, 'local_work_dir': None, '...
           │   │      │    │           └ <click.core.Context object at 0x10588ba10>
           │   │      │    └ <function kimi at 0x105ebe520>
           │   │      └ <TyperCommand kimi>
           │   └ <function Context.invoke at 0x1057722a0>
           └ <click.core.Context object at 0x10588ba10>
  File "/Users/guochunzhong/git/oss/kimi-cli/.venv/lib/python3.13/site-packages/click/core.py", line 824, in invoke
    return callback(*args, **kwargs)
           │         │       └ {'version': None, 'model_name': 'deepseek-r1', 'debug': True, 'verbose': False, 'agent_file': None, 'local_work_dir': None, '...
           │         └ ()
           └ <function kimi at 0x105ebe520>
  File "/Users/guochunzhong/git/oss/kimi-cli/.venv/lib/python3.13/site-packages/typer/main.py", line 691, in wrapper
    return callback(**use_params)
           │          └ {'version': None, 'verbose': False, 'debug': True, 'agent_file': None, 'model_name': 'deepseek-r1', 'local_work_dir': None, '...
           └ <function kimi at 0x105637b00>

  File "/Users/guochunzhong/git/oss/kimi-cli/src/kimi_cli/cli.py", line 336, in kimi
    succeeded = asyncio.run(_run())
                │       │   └ <function kimi.<locals>._run at 0x106ff7920>
                │       └ <function run at 0x104950540>
                └ <module 'asyncio' from '/opt/homebrew/Cellar/python@3.13/3.13.9_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/as...

  File "/opt/homebrew/Cellar/python@3.13/3.13.9_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/asyncio/runners.py", line 195, in run
    return runner.run(main)
           │      │   └ <coroutine object kimi.<locals>._run at 0x1069df490>
           │      └ <function Runner.run at 0x1055b2200>
           └ <asyncio.runners.Runner object at 0x107026ba0>

  File "/opt/homebrew/Cellar/python@3.13/3.13.9_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           │    │     │                  └ <Task pending name='Task-1' coro=<kimi.<locals>._run() running at /Users/guochunzhong/git/oss/kimi-cli/src/kimi_cli/cli.py:29...
           │    │     └ <function BaseEventLoop.run_until_complete at 0x1055abc40>
           │    └ <_UnixSelectorEventLoop running=True closed=False debug=False>
           └ <asyncio.runners.Runner object at 0x107026ba0>

  File "/opt/homebrew/Cellar/python@3.13/3.13.9_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/asyncio/base_events.py", line 712, in run_until_complete
    self.run_forever()
    │    └ <function BaseEventLoop.run_forever at 0x1055abba0>
    └ <_UnixSelectorEventLoop running=True closed=False debug=False>

  File "/opt/homebrew/Cellar/python@3.13/3.13.9_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/asyncio/base_events.py", line 683, in run_forever
    self._run_once()
    │    └ <function BaseEventLoop._run_once at 0x1055b19e0>
    └ <_UnixSelectorEventLoop running=True closed=False debug=False>

  File "/opt/homebrew/Cellar/python@3.13/3.13.9_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/asyncio/base_events.py", line 2050, in _run_once
    handle._run()
    │      └ <function Handle._run at 0x104f3fba0>
    └ <Handle Task.task_wakeup()>

  File "/opt/homebrew/Cellar/python@3.13/3.13.9_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/asyncio/events.py", line 89, in _run
    self._context.run(self._callback, *self._args)
    │    │            │    │           │    └ <member '_args' of 'Handle' objects>
    │    │            │    │           └ <Handle Task.task_wakeup()>
    │    │            │    └ <member '_callback' of 'Handle' objects>
    │    │            └ <Handle Task.task_wakeup()>
    │    └ <member '_context' of 'Handle' objects>
    └ <Handle Task.task_wakeup()>

  File "/Users/guochunzhong/git/oss/kimi-cli/src/kimi_cli/cli.py", line 292, in _run
    succeeded = await instance.run_shell_mode(command)
                      │        │              └ None
                      │        └ <function KimiCLI.run_shell_mode at 0x1070eaf20>
                      └ <kimi_cli.app.KimiCLI object at 0x108fc27b0>

  File "/Users/guochunzhong/git/oss/kimi-cli/src/kimi_cli/app.py", line 197, in run_shell_mode
    return await app.run(command)
                 │   │   └ None
                 │   └ <function ShellApp.run at 0x1098905e0>
                 └ <kimi_cli.ui.shell.ShellApp object at 0x10954d940>

  File "/Users/guochunzhong/git/oss/kimi-cli/src/kimi_cli/ui/shell/__init__.py", line 91, in run
    await self._run_soul_command(user_input.content, user_input.thinking)
          │    │                 │          │        │          └ False
          │    │                 │          │        └ UserInput(mode=<PromptMode.AGENT: 'agent'>, thinking=False, command='howto configure kimi cli with ANTHROPIC style key?', con...
          │    │                 │          └ [TextPart(type='text', text='howto configure kimi cli with ANTHROPIC style key?')]
          │    │                 └ UserInput(mode=<PromptMode.AGENT: 'agent'>, thinking=False, command='howto configure kimi cli with ANTHROPIC style key?', con...
          │    └ <function ShellApp._run_soul_command at 0x1098907c0>
          └ <kimi_cli.ui.shell.ShellApp object at 0x10954d940>

> File "/Users/guochunzhong/git/oss/kimi-cli/src/kimi_cli/ui/shell/__init__.py", line 196, in _run_soul_command
    await run_soul(
          └ <function run_soul at 0x10703d080>

  File "/Users/guochunzhong/git/oss/kimi-cli/src/kimi_cli/soul/__init__.py", line 148, in run_soul
    soul_task.result()  # this will raise if any exception was raised in the run task
    │         └ <method 'result' of '_asyncio.Task' objects>
    └ <Task finished name='Task-31' coro=<KimiSoul.run() done, defined at /Users/guochunzhong/git/oss/kimi-cli/src/kimi_cli/soul/ki...

  File "/Users/guochunzhong/git/oss/kimi-cli/src/kimi_cli/soul/kimisoul.py", line 174, in run
    await self._agent_loop()
          │    └ <function KimiSoul._agent_loop at 0x1070ea020>
          └ <kimi_cli.soul.kimisoul.KimiSoul object at 0x108fc2510>

  File "/Users/guochunzhong/git/oss/kimi-cli/src/kimi_cli/soul/kimisoul.py", line 226, in _agent_loop
    finished = await self._step()
                     │    └ <function KimiSoul._step at 0x1070ea0c0>
                     └ <kimi_cli.soul.kimisoul.KimiSoul object at 0x108fc2510>

  File "/Users/guochunzhong/git/oss/kimi-cli/src/kimi_cli/soul/kimisoul.py", line 270, in _step
    result = await _kosong_step_with_retry()
                   └ <function KimiSoul._step.<locals>._kosong_step_with_retry at 0x1077532e0>

  File "/Users/guochunzhong/git/oss/kimi-cli/.venv/lib/python3.13/site-packages/tenacity/asyncio/__init__.py", line 189, in async_wrapped
    return await copy(fn, *args, **kwargs)
                 │    │    │       └ {}
                 │    │    └ ()
                 │    └ <function KimiSoul._step.<locals>._kosong_step_with_retry at 0x1099f1800>
                 └ <AsyncRetrying object at 0x1099510f0 (stop=<tenacity.stop.stop_after_attempt object at 0x10a051090>, wait=<tenacity.wait.wait...
  File "/Users/guochunzhong/git/oss/kimi-cli/.venv/lib/python3.13/site-packages/tenacity/asyncio/__init__.py", line 111, in __call__
    do = await self.iter(retry_state=retry_state)
               │    │                └ <RetryCallState 4463072016: attempt #1; slept for 0.0; last result: failed (APIStatusError Error code: 400 - {'error': {'mess...
               │    └ <function AsyncRetrying.iter at 0x1070e87c0>
               └ <AsyncRetrying object at 0x1099510f0 (stop=<tenacity.stop.stop_after_attempt object at 0x10a051090>, wait=<tenacity.wait.wait...
  File "/Users/guochunzhong/git/oss/kimi-cli/.venv/lib/python3.13/site-packages/tenacity/asyncio/__init__.py", line 153, in iter
    result = await action(retry_state)
                   │      └ <RetryCallState 4463072016: attempt #1; slept for 0.0; last result: failed (APIStatusError Error code: 400 - {'error': {'mess...
                   └ <function wrap_to_async_func.<locals>.inner at 0x107753380>
  File "/Users/guochunzhong/git/oss/kimi-cli/.venv/lib/python3.13/site-packages/tenacity/_utils.py", line 99, in inner
    return call(*args, **kwargs)
           │     │       └ {}
           │     └ (<RetryCallState 4463072016: attempt #1; slept for 0.0; last result: failed (APIStatusError Error code: 400 - {'error': {'mes...
           └ <function BaseRetrying._post_retry_check_actions.<locals>.<lambda> at 0x107753560>
  File "/Users/guochunzhong/git/oss/kimi-cli/.venv/lib/python3.13/site-packages/tenacity/__init__.py", line 400, in <lambda>
    self._add_action_func(lambda rs: rs.outcome.result())
                                 │   │  │       └ <function Future.result at 0x104b00900>
                                 │   │  └ <Future at 0x10a052490 state=finished raised APIStatusError>
                                 │   └ <RetryCallState 4463072016: attempt #1; slept for 0.0; last result: failed (APIStatusError Error code: 400 - {'error': {'mess...
                                 └ <RetryCallState 4463072016: attempt #1; slept for 0.0; last result: failed (APIStatusError Error code: 400 - {'error': {'mess...

  File "/opt/homebrew/Cellar/python@3.13/3.13.9_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           └ None

  File "/opt/homebrew/Cellar/python@3.13/3.13.9_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
          └ None

  File "/Users/guochunzhong/git/oss/kimi-cli/.venv/lib/python3.13/site-packages/tenacity/asyncio/__init__.py", line 114, in __call__
    result = await fn(*args, **kwargs)
                   │   │       └ {}
                   │   └ ()
                   └ <function KimiSoul._step.<locals>._kosong_step_with_retry at 0x1099f1800>

  File "/Users/guochunzhong/git/oss/kimi-cli/src/kimi_cli/soul/kimisoul.py", line 261, in _kosong_step_with_retry
    return await kosong.step(
                 │      └ <function step at 0x1069d6d40>
                 └ <module 'kosong' from '/Users/guochunzhong/git/oss/kimi-cli/.venv/lib/python3.13/site-packages/kosong/__init__.py'>

  File "/Users/guochunzhong/git/oss/kimi-cli/.venv/lib/python3.13/site-packages/kosong/__init__.py", line 158, in step
    result = await generate(
                   └ <function generate at 0x106a5ccc0>
  File "/Users/guochunzhong/git/oss/kimi-cli/.venv/lib/python3.13/site-packages/kosong/_generate.py", line 53, in generate
    stream = await chat_provider.generate(system_prompt, tools, history)
                   │             │        │              │      └ [Message(role='assistant', name=None, content=[TextPart(type='text', text='<system>kimi-cli::agents-md:ab602e64b1c2d4cf82b9e2...
                   │             │        │              └ [Tool(name='Task', description='Spawn a subagent to perform a specific task. Subagent will be spawned with a fresh context wi...
                   │             │        └ "You are Kimi CLI. You are an interactive CLI agent specializing in software engineering tasks. Your primary goal is to help ...
                   │             └ <function OpenAILegacy.generate at 0x107bf1bc0>
                   └ <kosong.contrib.chat_provider.openai_legacy.OpenAILegacy object at 0x10a051590>
  File "/Users/guochunzhong/git/oss/kimi-cli/.venv/lib/python3.13/site-packages/kosong/contrib/chat_provider/openai_legacy.py", line 125, in generate
    raise convert_error(e) from e
          └ <function convert_error at 0x107bf2c00>

kosong.chat_provider.APIStatusError: Error code: 400 - {'error': {'message': 'Failed to deserialize the JSON body into the target type: messages[4]: invalid type: sequence, expected a string at line 1 column 8822', 'type': 'invalid_request_error', 'param': None, 'code': 'invalid_request_error'}}
2025-11-24 19:41:02.126 | DEBUG    | kimi_cli.ui.shell:run:63 - Exiting by EOF

```