### PR TITLE
fix: map to role=developer for OpenAI models

### DIFF
--- a/src/kosong/contrib/chat_provider/openai_responses.py
+++ b/src/kosong/contrib/chat_provider/openai_responses.py
@@ -217,6 +217,8 @@ def message_to_openai(
     """
 
     role = message.role
+    if is_openai_model and role == "system":
+        role = "developer"
 
     # tool role → function_call_output (return value from a prior tool call)
     if role == "tool":


### PR DESCRIPTION
https://github.com/MoonshotAI/kosong/blob/63374cd86d033b992324be12a131dda300edc253/src/kosong/contrib/chat_provider/openai_responses.py#L207-L217


For `message_to_openai` function, if the rule in doc is right: `role == system: map to role=developer for OpenAI models, otherwise kept`, we should do this map correctly.(Currently the `is_openai_model` parameter is not used.)