### PR TITLE
fix(kimi): omit `stream_options` when `stream` is False

### DIFF
--- a/src/kosong/chat_provider/kimi.py
+++ b/src/kosong/chat_provider/kimi.py
@@ -5,7 +5,7 @@ from collections.abc import AsyncIterator, Sequence
 from typing import TYPE_CHECKING, Any, Self, TypedDict, Unpack, cast
 
 import httpx
-from openai import AsyncOpenAI, AsyncStream, OpenAIError
+from openai import AsyncOpenAI, AsyncStream, OpenAIError, omit
 from openai.types.chat import (
     ChatCompletion,
     ChatCompletionChunk,
@@ -128,7 +128,7 @@ class Kimi(ChatProvider):
                 messages=messages,
                 tools=(tool_to_kimi(tool) for tool in tools),
                 stream=self.stream,
-                stream_options={"include_usage": True} if self.stream else None,
+                stream_options={"include_usage": True} if self.stream else omit,
                 **generation_kwargs,
             )
             return KimiStreamedMessage(response)

--- a/src/kosong/contrib/chat_provider/openai_legacy.py
+++ b/src/kosong/contrib/chat_provider/openai_legacy.py
@@ -116,7 +116,7 @@ class OpenAILegacy:
                 messages=messages,
                 tools=(tool_to_openai(tool) for tool in tools),
                 stream=self.stream,
-                stream_options={"include_usage": True},
+                stream_options={"include_usage": True} if self.stream else omit,
                 reasoning_effort=self._reasoning_effort,
                 **generation_kwargs,
             )


### PR DESCRIPTION
#49 

自己测了可以。自测代码：

```python
    provider = Kimi(model=get_env_or_raise("KIMI_MODEL"), stream=False)
    summary_part = TextPart(text='')
    async for part in await provider.generate(
        system_prompt="",
        tools=[],
        history=[Message(role="user", content=[TextPart(text='hello world')])],
    ):
        summary_part.merge_in_place(part)
```

## 测试用例

看起来要实际运行才会触发，只是在`tests/test_chat_provider.py` 增加 `base = Kimi(model="dummy", api_key="sk-1234567890", stream=False)` 测不出来。





<!--This is a translation content dividing line, the content below is generated by machine, please do not modify the content below-->
---
#49

You can test it yourself. Self-test code:

```python
    provider = Kimi(model=get_env_or_raise("KIMI_MODEL"), stream=False)
    summary_part = TextPart(text='')
    async for part in await provider.generate(
        system_prompt="",
        tools=[],
        history=[Message(role="user", content=[TextPart(text='hello world')])],
    ):
        summary_part.merge_in_place(part)
```

## Test case

It seems that it will be triggered only when it is actually run. Just add `base = Kimi(model="dummy", api_key="sk-1234567890", stream=False)` in `tests/test_chat_provider.py` and it cannot be measured.
