### PR TITLE
refactor: unify text content handling across providers

### DIFF
--- a/src/kosong/contrib/chat_provider/anthropic.py
+++ b/src/kosong/contrib/chat_provider/anthropic.py
@@ -428,8 +428,8 @@ def _tool_result_message_to_block(message: Message) -> ToolResultBlockParam:
 
     content: str | list[ToolResultContent]
     # If content has only one part and the part is a TextPart, use the text directly
-    if len(message.content) == 1 and isinstance(message.content[0], TextPart):
-        content = message.content[0].text
+    if message.only_has_text_contents():
+        content = message.extract_text("\n")
     else:
         # Otherwise, map parts to content blocks
         blocks: list[ToolResultContent] = []

--- a/src/kosong/message.py
+++ b/src/kosong/message.py
@@ -235,8 +235,9 @@ class Message(BaseModel):
 
     @field_serializer("content")
     def _serialize_content(self, content: list[ContentPart]) -> str | list[dict[str, Any]] | None:
-        if len(content) == 1 and isinstance(content[0], TextPart):
-            return content[0].text
+        text_parts = [part for part in content if isinstance(part, TextPart)]
+        if 0 < len(content) == len(text_parts):
+            return "\n".join([text_part.text for text_part in text_parts])
         return [part.model_dump() for part in content]
 
     @field_validator("content", mode="before")
@@ -272,3 +273,6 @@ class Message(BaseModel):
     def extract_text(self, sep: str = "") -> str:
         """Extract and concatenate all text parts in the message content."""
         return sep.join(part.text for part in self.content if isinstance(part, TextPart))
+
+    def only_has_text_contents(self) -> bool:
+        return len(self.content) > 0 and all([isinstance(part, TextPart) for part in self.content])


### PR DESCRIPTION
- Update message serialization to handle multiple text parts consistently
- Add only_has_text_contents() helper method to Message class
- Refactor OpenAI Responses provider to use new message API
- Update Anthropic provider to use consistent text content handling
- When message contains only text parts, join them with newlines instead of using single text part logic